### PR TITLE
Update 07_asymptotics.md

### DIFF
--- a/manuscript/07_asymptotics.md
+++ b/manuscript/07_asymptotics.md
@@ -236,7 +236,7 @@ The interval takes the form:
 
 Replacing {$$}p{/$$} by {$$}\hat p{/$$} in the standard error results in what
 is called a Wald confidence interval for {$$}p{/$$}. Remember also that
-{$$}p(1 - p){/$$} is maximized at 1/4. Plugging this in and setting
+{$$}p(1 - p){/$$} is maximized at 1/2. Plugging this in and setting
 our {$$}Z{/$$} quantile as 2 (which is about a 95% interval) we find
 that a quick and dirty confidence interval is:
 


### PR DESCRIPTION
Changing expected maximum for p(1 - p) in line 239.

When revieweing the material for the Statistical Inference course on coursera I noted that the maximum for p(1 - p) was originally reported in the book as 1/4, while in the lecture and the book in p. 34 it is correctly reported as 1/2. I therefore thought important to suggest changing the value in this pull requerst to the right value of 1/2 instead to the wrong one (1/4).
