### PR TITLE
08_tcis.md: unequal variance interval is narrower

### DIFF
--- a/manuscript/08_tcis.md
+++ b/manuscript/08_tcis.md
@@ -304,7 +304,7 @@ unequal variances would be wise. Recall the code is
 [2,] -104.7 -18.30
 ~~~
 
-This interval is remains entirely below zero. However, it is wider than the equal variance interval.
+This interval remains entirely below zero and it is narrower than the equal variance interval.
 
 ## Summary notes
 * The *t* distribution is useful for small sample size comparisons.


### PR DESCRIPTION
The equal variance interval is `[-108.1, -14.81]` and the unequal variance interval is `[-104.7, -18.30]`. The latter is a narrower interval than the former, not wider like previously stated in the text.
