### PR TITLE
Updates:

### DIFF
--- a/manuscript/02_probability.md
+++ b/manuscript/02_probability.md
@@ -109,20 +109,20 @@ Answer: No, the events can simultaneously occur and so
 exclusive. To elaborate let:
 
 {$$}
- \begin{eqnarray*}
-     A_1 & = & \{\mbox{Person has sleep apnea}\} \\
-A_2 & = & \{\mbox{Person has RLS}\}
-   \end{eqnarray*}
+ \begin{aligned}
+     A_1 & = \{\mbox{Person has sleep apnea}\} \\
+A_2 & = \{\mbox{Person has RLS}\}
+   \end{aligned}
  {/$$}
 
 Then
 
 {$$}
- \begin{eqnarray*}
-     P(A_1 \cup A_2 ) & = & P(A_1) + P(A_2) - P(A_1 \cap
+ \begin{aligned}
+     P(A_1 \cup A_2 ) & = P(A_1) + P(A_2) - P(A_1 \cap
 A_2) \\
-    & = & 0.13 - \mbox{Probability of having both}
-   \end{eqnarray*}
+    & = 0.13 - \mbox{Probability of having both}
+   \end{aligned}
  {/$$}
 
 Given the scenario, it's likely that some fraction of the population has both.

--- a/manuscript/03_conditional.md
+++ b/manuscript/03_conditional.md
@@ -132,12 +132,12 @@ the specificity, {$$}P(- ~|~ D^c) =.985{/$$} and the prevalence
 {$$}P(D) = .001{/$$}.
 
 {$$}
-\begin{eqnarray*}
-P(D ~|~ +) & = &\frac{P(+~|~D)P(D)}{P(+~|~D)P(D) + P(+~|~D^c)P(D^c)}\\
- & = & \frac{P(+~|~D)P(D)}{P(+~|~D)P(D) + \{1-P(-~|~D^c)\}\{1 - P(D)\}} \\
- & = & \frac{.997\times .001}{.997 \times .001 + .015 \times .999}\\
- & = & .062
-\end{eqnarray*}
+\begin{aligned}
+P(D ~|~ +) & = \frac{P(+~|~D)P(D)}{P(+~|~D)P(D) + P(+~|~D^c)P(D^c)}\\
+ & = \frac{P(+~|~D)P(D)}{P(+~|~D)P(D) + \{1-P(-~|~D^c)\}\{1 - P(D)\}} \\
+ & = \frac{.997\times .001}{.997 \times .001 + .015 \times .999}\\
+ & = .062
+\end{aligned}
 {/$$}
 
 In this population a positive test result only suggests a 6% probability that

--- a/manuscript/LittleInferenceBook.Rmd
+++ b/manuscript/LittleInferenceBook.Rmd
@@ -1,5 +1,9 @@
 ---
 output:
+  pdf_document:
+    toc: true
+    includes:
+      in_header: title.tex
   html_document:
     toc: true
     toc_depth: 2

--- a/manuscript/title.tex
+++ b/manuscript/title.tex
@@ -1,0 +1,8 @@
+\usepackage{titling}
+\setlength{\droptitle}{-1in}
+\pretitle{%
+  \begin{center}
+  \LARGE
+  \includegraphics{images/title_page.png}\\[\bigskipamount]
+}
+\posttitle{\end{center}}


### PR DESCRIPTION
LittleInferenceBook.Rmd: When knitting to PDF, was failing to include a title page. Added reference to new file title.tex for that
title.tex: Uses titling package to pull the quincunx figure
02_probability.md: When knitting to PDF, {eqnarray_} was failing to knit using MikTex on Windows. Replaced it with {aligned}
03_conditional.md: When knitting to PDF, {eqnarray_} was failing to knit using MikTex on Windows. Replaced it with {aligned}
