### PR TITLE
Corrected Youtube link that was not appearing.

### DIFF
--- a/manuscript/02_probability.md
+++ b/manuscript/02_probability.md
@@ -14,8 +14,7 @@ For the interested student, I would recommend the books and work by Ian Hacking 
 In this lecture, we will cover the fundamentals of probability at low enough of
 a level to have a basic understanding for the rest of the series. For a more
 complete treatment see the class Mathematical Biostatistics Boot Camp 1, which
-can be viewed on YouTube [here](Youtube:
-www.youtube.com/playlist?list=PLpl-gQkQivXhk6qSyiNj51qamjAtZISJ-).  In addition,
+can be viewed on YouTube [here](https://www.youtube.com/playlist?list=PLpl-gQkQivXhk6qSyiNj51qamjAtZISJ-).  In addition,
 there's  the actual [Coursera course](Coursera:
 www.coursera.org/course/biostats) that I run periodically (this is the first
 Coursera class that I ever taught).  Also there are a set of [notes on


### PR DESCRIPTION
In section "Where to get a more thorough treatment of probability" the link to the video lectures of to the Mathematical Biostatistics Boot Camp 1 had a newline, which was preventing it from displaying.
